### PR TITLE
Fixed attachment type comparison problem

### DIFF
--- a/postmark/core.py
+++ b/postmark/core.py
@@ -8,7 +8,7 @@ __contributors__    = "Dave Martorana (themartorana), Bill Jones (oraclebill), R
 #
 # Imports (JSON library based on import try)
 
-import email
+import email.mime.base
 import sys
 import urllib
 import urllib2
@@ -50,7 +50,8 @@ class PMMail(object):
         html_body:      Email message in HTML
         text_body:      Email message in plain text
         custom_headers: A dictionary of key-value pairs of custom headers.
-        attachments:    A list of dictionaries describing attachments.
+        attachments:    A list of tuples or email.mime.base.MIMEBase objects
+                        describing attachments.
         '''
         # initialize properties
         self.__api_key = None


### PR DESCRIPTION
While 99e2f70382de43aec9c9beb2c0bbd77781752a1d introduced setup.py and "made attachments work," there was an error in the code.

I opened an issue (themartorana/python-postmark#2) which details the following error:

```
AttributeError: 'module' object has no attribute 'base'
```

You can see the whole stack trace on the issue page.

For some reason, the scope of the original `import email` doesn't allow that attribute to be seen. I've fixed the problem. I'm guessing that joshourisman was passing in tuples while testing (so the code never executed the statement `isinstance(attachment, email.mime.base.MIMEBase)`, or else his version of Python is different from mine (which is 2.6.5 on Linux) and the `email` package is differs. Python packaging is still a bit enigmatic to me.

I also updated the docstring description for the `attachments` parameter, because it was wrong.

I am able to send e-mails with attachments using my edits. I didn't attempt to use `MIMEBase` objects because I haven't used them before and that doesn't seem like it would be an issue. You can close the issue I opened if you pull this commit.
