### PR TITLE
Adding settings variable to switch test mode

### DIFF
--- a/postmark/django_backend.py
+++ b/postmark/django_backend.py
@@ -15,6 +15,7 @@ class EmailBackend(BaseEmailBackend):
         if not self.api_key:
             raise ImproperlyConfigured('POSTMARK API key must be set in Django settings file or passed to backend constructor.')            
         self.default_sender = getattr(settings, 'POSTMARK_SENDER', default_sender)
+        self.test_mode = getattr(settings, 'POSTMARK_TEST_MODE', False) 
                                     
     def send_messages(self, email_messages):
         """
@@ -67,7 +68,7 @@ class EmailBackend(BaseEmailBackend):
                                   custom_headers=custom_headers,
                                   attachments=attachments)
 
-            postmark_message.send()
+            postmark_message.send(test=self.test_mode)
         except:
             if self.fail_silently:
                 return False


### PR DESCRIPTION
Recently I connected python-postmark email backend into my Django project and it rocks! thanks for the app!

My only problem was my code was not very reliable at that time, so sometimes i was sending too many emails and those bugs cost money. So after realizing that test mode was there, I created this 'POSTMARK_TEST_MODE' variable, which I think is very helpful. If you pull the commit, the docs should be updated.

Regards,
Miguel Araujo
