### PR TITLE
PMMail should respect Django settings, using them as overridable defaults

### DIFF
--- a/postmark/core.py
+++ b/postmark/core.py
@@ -98,9 +98,10 @@ class PMMail(object):
         try:
             from django import VERSION
             from django.conf import settings as django_settings
-            self.__api_key = django_settings.POSTMARK_API_KEY
             self.__user_agent = '%s (Django %s)' % (self.__user_agent, '_'.join([str(var) for var in VERSION]))
-            if not self.__sender:
+            if not self.__api_key and hasattr(django_settings, 'POSTMARK_API_KEY'):
+                self.__api_key = django_settings.POSTMARK_API_KEY
+            if not self.__sender and hasattr(django_settings, 'POSTMARK_SENDER'):
                 self.__sender = django_settings.POSTMARK_SENDER
         except ImportError:
             pass
@@ -296,7 +297,7 @@ class PMMail(object):
             raise PMMailMissingValueException('Cannot send an e-mail without either an HTML or text version of your e-mail body')
 
     
-    def send(self, test=False):
+    def send(self, test=None):
         '''
         Send the email through the Postmark system.  
         Pass test=True to just print out the resulting
@@ -359,6 +360,14 @@ class PMMail(object):
 #         if (self.__html_body and not self.__text_body) and self.__multipart:
 #             # TODO: Set up regex to strip html
 #             pass
+        
+        # If test is not specified, attempt to read the Django setting
+        if test is None:
+            try:
+                from django.conf import settings as django_settings
+                test = getattr(django_settings, "POSTMARK_TEST_MODE", None)
+            except ImportError:
+                pass
         
         # If this is a test, just print the message
         if test:
@@ -438,9 +447,9 @@ class PMBounceManager(object):
         try:
             from django import VERSION
             from django.conf import settings as django_settings
-            self.__api_key = django_settings.POSTMARK_API_KEY
+            if not self.__api_key and hasattr(django_settings, 'POSTMARK_API_KEY'):
+                self.__api_key = django_settings.POSTMARK_API_KEY
             self.__user_agent = '%s (Django %s)' % (self.__user_agent, '_'.join([str(var) for var in VERSION]))
-            self.__sender = django_settings.POSTMARK_SENDER
         except ImportError:
             pass
             


### PR DESCRIPTION
This would be really useful to me, as it allows me to use POSTMARK_TEST_MODE transparently in the context of different settings files (production/development) without having to use the Django email backend. I hope it might be useful to others, too.

• `PMMail` now treats the any Django `POSTMARK_*` settings as defaults when used in the context of a Django project, unless they are overridden by a kwarg passed to its constuctor or by setting an attribute post–construction;
• `PMMail.send` now respects the `POSTMARK_TEST_MODE` Django setting unless it is otherwise specified by the `test` kwarg.
