### PR TITLE
Subjects with ugettext_lazy from django.utils.translation

### DIFF
--- a/postmark/django_backend.py
+++ b/postmark/django_backend.py
@@ -57,7 +57,10 @@ class EmailBackend(BaseEmailBackend):
             if message.attachments and isinstance(message.attachments, list):
                 if len(message.attachments):
                     attachments = message.attachments
-            
+
+            if message.subject.__class__.__name__ ==  "__proxy__":
+                message.subject = unicode(message.subject)
+
             postmark_message = PMMail(api_key=self.api_key, 
                                   subject=message.subject,
                                   sender=message.from_email,


### PR DESCRIPTION
Not sure if this is the best way to handle it, but strings marked with _("this") in Django have issues when assigned to the subject of a message. This handles those so-called proxy strings.
