### PR TITLE
Please pull base64 encoding for the Django API

### DIFF
--- a/postmark/django_backend.py
+++ b/postmark/django_backend.py
@@ -59,6 +59,7 @@ class EmailBackend(BaseEmailBackend):
             return False            
         recipients = ','.join(message.to)
         recipients_bcc = ','.join(message.bcc)
+        recipients_cc = ','.join(message.cc)
         
         html_body = None
         if isinstance(message, EmailMultiAlternatives):
@@ -83,6 +84,7 @@ class EmailBackend(BaseEmailBackend):
                               subject=message.subject,
                               sender=message.from_email,
                               to=recipients,
+                              cc=recipients_cc, 
                               bcc=recipients_bcc,
                               text_body=message.body,
                               html_body=html_body,

--- a/postmark/django_backend.py
+++ b/postmark/django_backend.py
@@ -1,3 +1,5 @@
+import base64
+
 from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
 from django.core.exceptions import ImproperlyConfigured
@@ -77,7 +79,7 @@ class EmailBackend(BaseEmailBackend):
             attachments = []
             if message.attachments and isinstance(message.attachments, list):
                 if len(message.attachments):
-                    attachments = message.attachments
+                    attachments = [(f, base64.encodestring(content), m) for (f, content, m) in message.attachments]
             
             postmark_message = PMMail(api_key=self.api_key, 
                                   subject=message.subject,

--- a/test/demo/urls.py
+++ b/test/demo/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 # Uncomment the next two lines to enable the admin:
 # from django.contrib import admin


### PR DESCRIPTION
Hi,

This commit converts files to base64 encoding (the python-postmark standard). In a Django emailmessage there is no expectation about any given format, so it will currently fail with the following rather cryptic error message:

```
 File "[..]django/core/mail/message.py", line 175, in send
   return self.get_connection(fail_silently).send_messages([self])

 File "[..]postmark/django_backend.py", line 50, in send_messages
   sent = self._send(message)

 File "[..]postmark/django_backend.py", line 94, in _send
   postmark_message.send(test=self.test_mode)

 File "[..]postmark/core.py", line 389, in send
   json.dumps(json_message),

 File "/usr/lib/python2.6/json/__init__.py", line 230, in dumps
   return _default_encoder.encode(obj)

 File "/usr/lib/python2.6/json/encoder.py", line 367, in encode
   chunks = list(self.iterencode(o))

 File "/usr/lib/python2.6/json/encoder.py", line 309, in _iterencode
   for chunk in self._iterencode_dict(o, markers):

 File "/usr/lib/python2.6/json/encoder.py", line 275, in _iterencode_dict
   for chunk in self._iterencode(value, markers):

 File "/usr/lib/python2.6/json/encoder.py", line 306, in _iterencode
   for chunk in self._iterencode_list(o, markers):

 File "/usr/lib/python2.6/json/encoder.py", line 204, in _iterencode_list
   for chunk in self._iterencode(value, markers):

 File "/usr/lib/python2.6/json/encoder.py", line 309, in _iterencode
   for chunk in self._iterencode_dict(o, markers):

 File "/usr/lib/python2.6/json/encoder.py", line 275, in _iterencode_dict
   for chunk in self._iterencode(value, markers):

 File "/usr/lib/python2.6/json/encoder.py", line 294, in _iterencode
   yield encoder(o)

UnicodeDecodeError: 'utf8' codec can't decode bytes in position 12-13: invalid data
```