### PR TITLE
Better hierarchy for importing JSON. Simplejson is faster than the builtin "json" due to the compiled C _speedups module.

### DIFF
--- a/postmark/core.py
+++ b/postmark/core.py
@@ -19,12 +19,16 @@ import urllib2
 import httplib
 
 try:
-    import json                     
+    import simplejson as json
 except ImportError:
     try:
-        import simplejson as json
+        import json
     except ImportError:
-        raise Exception('Cannot use python-postmark library without Python 2.6 or greater, or Python 2.4 or 2.5 and the "simplejson" library')
+        try:
+            # Last ditch effort to try and grab it from Django if they're using Django
+            from django.utils import simplejson as json
+        except ImportError:
+            raise Exception('Cannot use python-postmark library without Python 2.6 or greater, or Python 2.4 or 2.5 and the "simplejson" library')
 
 class PMJSONEncoder(json.JSONEncoder):
 	def default(self, o):


### PR DESCRIPTION
Not much to explain. Simplejson + _speedups is much faster than default JSON, so it should be preferred when importing.

And lastly, falls back to Django's implementation as a last effort in-case both imports fail, but they're using the module from with Django.
