### PR TITLE
Implements base64 encoding

### DIFF
--- a/postmark/django_backend.py
+++ b/postmark/django_backend.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
 from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import EmailMessage, EmailMultiAlternatives
+import base64
 
 from core import PMMail, PMBatchMail
 

--- a/postmark/django_backend.py
+++ b/postmark/django_backend.py
@@ -75,9 +75,14 @@ class EmailBackend(BaseEmailBackend):
         attachments = []
         if message.attachments and isinstance(message.attachments, list):
             if len(message.attachments):
-                attachments = message.attachments
-        
-        postmark_message = PMMail(api_key=self.api_key, 
+                for item in message.attachments:
+                    if isinstance(item, tuple):
+                        (f, content, m) = item
+                        attachments.append((f, base64.encodestring(content), m))
+                    else:
+                        attachments.append(item)
+
+        postmark_message = PMMail(api_key=self.api_key,
                               subject=message.subject,
                               sender=message.from_email,
                               to=recipients,


### PR DESCRIPTION
Fixes the issue from this pull request (https://github.com/themartorana/python-postmark/pull/13), but it also handles the case when a MimeBase object is passed.

https://docs.djangoproject.com/en/1.4/topics/email/



