### PR TITLE
check if get_all params are empty, remove it from url params if empty

### DIFF
--- a/postmark/core.py
+++ b/postmark/core.py
@@ -674,8 +674,18 @@ class PMBounceManager(object):
         
         self._check_values()
         
-        params = '?inactive=' + inactive + '&emailFilter=' + email_filter +'&tag=' + tag 
-        params += '&count=' + str(count) + '&offset=' + str(offset)
+        params = '?count=' + str(count) + '&offset=' + str(offset)
+
+        if inactive:
+            params+= "&inactive=" + str(inactive)
+
+        if tag:
+            params+= "&tag=" + str(inactive)
+
+        if email_filter:
+            params+= "&emailFilter=" + str(email_filter)
+
+
         
         req = urllib2.Request(  	
             __POSTMARK_URL__ + 'bounces' + params,

--- a/postmark/core.py
+++ b/postmark/core.py
@@ -680,13 +680,13 @@ class PMBounceManager(object):
             params+= "&inactive=" + str(inactive)
 
         if tag:
-            params+= "&tag=" + str(inactive)
+            params+= "&tag=" + str(tag)
 
         if email_filter:
             params+= "&emailFilter=" + str(email_filter)
 
 
-        
+        print params 
         req = urllib2.Request(  	
             __POSTMARK_URL__ + 'bounces' + params,
             None,


### PR DESCRIPTION
Empty values are causing the api to fail. Hence `get_all()` doesn't the correct result when some parameters are not passed. (like `inactive`).

