### PR TITLE
Don't require content_subtype to be set to "html"

### DIFF
--- a/postmark/django_backend.py
+++ b/postmark/django_backend.py
@@ -65,9 +65,6 @@ class EmailBackend(BaseEmailBackend):
                     html_body=alt[0]
                     break
 
-        if getattr(message, 'content_subtype', None) == 'html':
-            html_body=message.body
-
         reply_to = None
         custom_headers = {}
         if message.extra_headers and isinstance(message.extra_headers, dict):


### PR DESCRIPTION
This PR reverses the change made by 969b947dff076b32548f8d6a29f608cb8e7f9386

According to the [Django docs](https://docs.djangoproject.com/en/dev/topics/email/#sending-alternative-content-types), it's good practice to leave this attribute alone. More importantly, currently the example from the Django docs using `EmailMultiAlternatives` does not work! Even when you attach the html alternative content, Django still defaults `content_subtype` to `"plain"`, so the current version of python-postmark ignores the HTML and just sends text.

Please merge this, unless @joshowen has something else to add here that perhaps I'm missing?
