### PR TITLE
Provide fix for text based proxy changes

### DIFF
--- a/postmark/core.py
+++ b/postmark/core.py
@@ -42,6 +42,8 @@ class PMJSONEncoder(json.JSONEncoder):
         try:
             if hasattr(o, '_proxy____str_cast') and isinstance(o._proxy____str_cast, collections.Callable):
                 return o._proxy____str_cast()
+            elif hasattr(o, '_proxy____text_cast') and isinstance(o._proxy____text_cast, collections.Callable):
+                return o._proxy____text_cast()
             elif hasattr(o, '_proxy____unicode_cast'):
                 return str(o)
         except:


### PR DESCRIPTION
This catches an error whereby django 1.5+'s ugettext_lazy strings aren't properly converted (for subjects, for instance).

Example debugging session:

```
208                    else:
209                        return list(iterable)
210                    return JSONEncoder.default(self, o)
211
212            """
213  ->             raise TypeError(repr(o) + " is not JSON serializable")
214
215             def encode(self, o):
216                 """Return a JSON string representation of a Python data structure.
217
218            >>> from simplejson import JSONEncoder
(Pdb++) o
<django.utils.functional.__proxy__ object at 0x112a6f7d0>
(Pdb++) dir(o)
['__add__', '__class__', '__contains__', '__deepcopy__', '__delattr__', '__dict__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__getitem__', '__getnewargs__', '__getslice__', '__gt__', '__hash__', '__init__', '__le__', '__len__', '__lt__', '__mod__', '__module__', '__mul__', '__new__', '__prepare_class__', '__promise__', '__reduce__', '__reduce_ex__', '__repr__', '__rmod__', '__rmul__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__unicode__', '__weakref__', '_delegate_bytes', '_delegate_text', '_formatter_field_name_split', '_formatter_parser', '_proxy____args', '_proxy____bytes_cast', '_proxy____cast', '_proxy____dispatch', '_proxy____kw', '_proxy____text_cast', 'capitalize', 'center', 'count', 'decode', 'encode', 'endswith', 'expandtabs', 'find', 'format', 'index', 'isalnum', 'isalpha', 'isdecimal', 'isdigit', 'islower', 'isnumeric', 'isspace', 'istitle', 'isupper', 'join', 'ljust', 'lower', 'lstrip', 'partition', 'replace', 'rfind', 'rindex', 'rjust', 'rpartition', 'rsplit', 'rstrip', 'split', 'splitlines', 'startswith', 'strip', 'swapcase', 'title', 'translate', 'upper', 'zfill']
(Pdb++) o._proxy____text_cast()
u'[sprint.ly #7329] JavaScript exception on ProductTags in production. (#7329) was accepted'
```

I also believe this to be a PR that's more in-line with the style of the repo than #11
