### PR TITLE
Support HTML body for EmailMessage

### DIFF
--- a/postmark/django_backend.py
+++ b/postmark/django_backend.py
@@ -78,6 +78,9 @@ class EmailBackend(BaseEmailBackend):
                     html_body=alt[0]
                     break
 
+        elif getattr(message, 'content_subtype', None) == 'html':
+            html_body = message.body
+
         reply_to = None
         custom_headers = {}
         if message.extra_headers and isinstance(message.extra_headers, dict):

--- a/postmark/django_backend.py
+++ b/postmark/django_backend.py
@@ -71,6 +71,7 @@ class EmailBackend(BaseEmailBackend):
         recipients_cc = ','.join(message.cc)
         recipients_bcc = ','.join(message.bcc)
 
+        text_body = message.body
         html_body = None
         if isinstance(message, EmailMultiAlternatives):
             for alt in message.alternatives:
@@ -79,6 +80,8 @@ class EmailBackend(BaseEmailBackend):
                     break
 
         elif getattr(message, 'content_subtype', None) == 'html':
+            # Don't send html content as plain text
+            text_body = None
             html_body = message.body
 
         reply_to = None
@@ -99,7 +102,7 @@ class EmailBackend(BaseEmailBackend):
                               to=recipients,
                               cc=recipients_cc,
                               bcc=recipients_bcc,
-                              text_body=message.body,
+                              text_body=text_body,
                               html_body=html_body,
                               reply_to=reply_to,
                               custom_headers=custom_headers,


### PR DESCRIPTION
This change was added in #31 then removed in #36. The case for removal was that the recommended practice in the [Django docs](https://docs.djangoproject.com/en/dev/topics/email/#sending-alternative-content-types) is to use `EmailMultiAlternative` to attach an HTML version of the body. However, those docs also state to change the `content_subtype` if you want to only send an HTML version.

As far as I can tell, this change wouldn't affect any other cases and `html_body` will still be correctly set if using `EmailMultiAlternative` instead of setting `content_subtype` directly and the example given in the docs for `EmailMultiAlternative` correctly sends the alternative bodies.