### PR TITLE
Inactive Recipient error and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+- '2.7'
+- '3.2'
+- '3.3'
+- '3.4'
+script: python tests.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG for python-postmark
 ===============================
 
+Version 0.4.8
+-------------
+- Handle inactive recipient errors (nicholasserra)
+
 Version 0.4.7
 -------------
 - Fix base64 encoding in Django API for attachments (thanosd)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,5 +24,6 @@ Everyone that made python-postmark awesome
 - Michael Flaxman (https://github.com/mflaxman)
 - Ryan Kuczka (https://github.com/ryankuczka)
 - @thanosd (https://github.com/thanosd)
+- Nicholas Serra (https://github.com/nicholasserra)
 
 (Did I miss anyone?)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ See [CONTRIBUTORS.md](https://github.com/themartorana/python-postmark/blob/maste
 Changelog
 ----------
 
+Version 0.4.8
+- Handle inactive recipient errors (nicholasserra)
+
 Version 0.4.7
 - Fix base64 encoding in Django API for attachments (thanosd)
 
@@ -85,6 +88,9 @@ class PMMailServerErrorException(PMMailSendException):
 
 class PMMailURLException(PMMailSendException):
     #A URLError was caught - usually has to do with connectivity and the ability to reach the server.  The inner_exception will have the base URLError object.
+
+class PMMailInactiveRecipientException(PMMailSendException):
+    # 406: You tried to send a message to a recipient that has been marked as inactive. If this was a batch operation, the rest of the messages were still sent.
 ```
 
 TODO

--- a/postmark/__init__.py
+++ b/postmark/__init__.py
@@ -1,4 +1,4 @@
-__version__         = '0.4.7'
+__version__         = '0.4.8'
 __author__          = "Dave Martorana (http://davemartorana.com), Richard Cooper (http://frozenskys.com), Bill Jones (oraclebill), Dmitry Golomidov (deeGraYve)"
 __date__            = '2010-April-14'
 __url__             = 'http://postmarkapp.com'

--- a/postmark/core.py
+++ b/postmark/core.py
@@ -558,6 +558,9 @@ class PMBatchMail(object):
             message._check_values()
 
     def send(self, test=None):
+        # Has one of the messages caused an inactive recipient error?
+        inactive_recipient = False
+
         # Check messages for completeness prior to attempting to send
         self._check_values()
 
@@ -610,8 +613,17 @@ class PMBatchMail(object):
                         jsontxt = err.read()
                         jsonobj = json.loads(jsontxt)
                         desc = jsonobj['Message']
-                    except:
-                        desc = 'Description not given'
+                        error_code = jsonobj['ErrorCode']
+                    except KeyError:
+                        raise PMMailUnprocessableEntityException('Unprocessable Entity: Description not given')
+
+                    if error_code == 406:
+                        # One of the message recipients was inactive. Postmark still sends the
+                        # rest of the messages that have active recipients. Continue sending
+                        # the rest of the chunks.
+                        inactive_recipient = True
+                        continue
+
                     raise PMMailUnprocessableEntityException('Unprocessable Entity: %s' % desc)
                 elif err.code == 500:
                     raise PMMailServerErrorException('Internal server error at Postmark. Admins have been alerted.', err)
@@ -622,6 +634,10 @@ class PMBatchMail(object):
                     raise PMMailURLException('URLError: %d: The server couldn\'t fufill the request. (See "inner_exception" for details)' % err.code, err)
                 else:
                     raise PMMailURLException('URLError: The server couldn\'t fufill the request. (See "inner_exception" for details)', err)
+
+        if inactive_recipient:
+            raise PMMailInactiveRecipientException('You tried to send email to a recipient that has been marked as inactive.')
+
         return True
 
 
@@ -911,5 +927,13 @@ class PMMailURLException(PMMailSendException):
     A URLError was caught - usually has to do with connectivity
     and the ability to reach the server.  The inner_exception will
     have the base URLError object.
+    '''
+    pass
+
+class PMMailInactiveRecipientException(PMMailSendException):
+    '''
+    406: You tried to send a message to a recipient that has been marked as
+    inactive. If this was a batch operation, the rest of the messages were
+    still sent.
     '''
     pass

--- a/postmark/core.py
+++ b/postmark/core.py
@@ -470,8 +470,13 @@ class PMMail(object):
                     jsontxt = err.read().decode()
                     jsonobj = json.loads(jsontxt)
                     desc = jsonobj['Message']
-                except:
-                    desc = 'Description not given'
+                    error_code = jsonobj['ErrorCode']
+                except KeyError:
+                    raise PMMailUnprocessableEntityException('Unprocessable Entity: Description not given')
+
+                if error_code == 406:
+                    raise PMMailInactiveRecipientException('You tried to send email to a recipient that has been marked as inactive.')
+
                 raise PMMailUnprocessableEntityException('Unprocessable Entity: %s' % desc)
             elif err.code == 500:
                 raise PMMailServerErrorException('Internal server error at Postmark. Admins have been alerted.', err)

--- a/postmark/core.py
+++ b/postmark/core.py
@@ -602,7 +602,7 @@ class PMBatchMail(object):
             # Attempt send
             try:
                 result = urlopen(req)
-                jsontxt = result.read()
+                jsontxt = result.read().decode()
                 result.close()
                 if result.code == 200:
                     results = json.loads(jsontxt)
@@ -615,7 +615,7 @@ class PMBatchMail(object):
                     raise PMMailUnauthorizedException('Sending Unauthorized - incorrect API key.', err)
                 elif err.code == 422:
                     try:
-                        jsontxt = err.read()
+                        jsontxt = err.read().decode()
                         jsonobj = json.loads(jsontxt)
                         desc = jsonobj['Message']
                         error_code = jsonobj['ErrorCode']

--- a/postmark/core.py
+++ b/postmark/core.py
@@ -1,4 +1,4 @@
-__version__         = '0.4.7'
+__version__         = '0.4.8'
 __author__          = "Dave Martorana (http://davemartorana.com), Richard Cooper (http://frozenskys.com), Bill Jones (oraclebill), Dmitry Golomidov (deeGraYve)"
 __date__            = '2010-April-14'
 __url__             = 'http://postmarkapp.com'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Django==1.7
+mock

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="python-postmark",
-    version="0.4.7",
+    version="0.4.8",
     packages=['postmark'],
     author="Dave Martorana (http://davemartorana.com), Richard Cooper (http://frozenskys.com), Bill Jones (oraclebill), Dmitry Golomidov (deeGraYve)",
     license='BSD',

--- a/tests.py
+++ b/tests.py
@@ -1,10 +1,8 @@
 import sys
 import unittest
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+
+from io import BytesIO
 
 if sys.version_info[0] < 3:
     from urllib2 import HTTPError
@@ -23,8 +21,8 @@ from django.conf import settings
 
 class PMMailTests(unittest.TestCase):
     def test_406_error_inactive_recipient(self):
-        json_payload = StringIO()
-        json_payload.write('{"Message": "", "ErrorCode": 406}')
+        json_payload = BytesIO()
+        json_payload.write(b'{"Message": "", "ErrorCode": 406}')
         json_payload.seek(0)
 
         message = PMMail(sender='from@example.com', to='to@example.com',
@@ -35,8 +33,8 @@ class PMMailTests(unittest.TestCase):
             self.assertRaises(PMMailInactiveRecipientException, message.send)
 
     def test_422_error_unprocessable_entity(self):
-        json_payload = StringIO()
-        json_payload.write('{"Message": "", "ErrorCode": 422}')
+        json_payload = BytesIO()
+        json_payload.write(b'{"Message": "", "ErrorCode": 422}')
         json_payload.seek(0)
 
         message = PMMail(sender='from@example.com', to='to@example.com',
@@ -68,8 +66,8 @@ class PMBatchMailTests(unittest.TestCase):
             ),
         ]
 
-        json_payload = StringIO()
-        json_payload.write('{"Message": "", "ErrorCode": 406}')
+        json_payload = BytesIO()
+        json_payload.write(b'{"Message": "", "ErrorCode": 406}')
         json_payload.seek(0)
 
         batch = PMBatchMail(messages=messages, api_key='test')
@@ -90,8 +88,8 @@ class PMBatchMailTests(unittest.TestCase):
             ),
         ]
 
-        json_payload = StringIO()
-        json_payload.write('{"Message": "", "ErrorCode": 422}')
+        json_payload = BytesIO()
+        json_payload.write(b'{"Message": "", "ErrorCode": 422}')
         json_payload.seek(0)
 
         batch = PMBatchMail(messages=messages, api_key='test')

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,131 @@
+import sys
+import StringIO
+import unittest
+
+if sys.version_info[0] < 3:
+    from urllib2 import HTTPError
+else:
+    from urllib.error import HTTPError
+
+import mock
+
+from postmark import (
+    PMBatchMail, PMMail, PMMailInactiveRecipientException,
+    PMMailUnprocessableEntityException, PMMailServerErrorException
+)
+
+from django.conf import settings
+
+
+class PMMailTests(unittest.TestCase):
+    def test_406_error_inactive_recipient(self):
+        json_payload = StringIO.StringIO()
+        json_payload.write('{"Message": "", "ErrorCode": 406}')
+        json_payload.seek(0)
+
+        message = PMMail(sender='from@example.com', to='to@example.com',
+            subject='Subject', text_body='Body', api_key='test')
+
+        with mock.patch('postmark.core.urlopen', side_effect=HTTPError('',
+            422, '', {}, json_payload)):
+            self.assertRaises(PMMailInactiveRecipientException, message.send)
+
+    def test_422_error_unprocessable_entity(self):
+        json_payload = StringIO.StringIO()
+        json_payload.write('{"Message": "", "ErrorCode": 422}')
+        json_payload.seek(0)
+
+        message = PMMail(sender='from@example.com', to='to@example.com',
+            subject='Subject', text_body='Body', api_key='test')
+
+        with mock.patch('postmark.core.urlopen', side_effect=HTTPError('',
+            422, '', {}, json_payload)):
+            self.assertRaises(PMMailUnprocessableEntityException, message.send)
+
+    def test_500_error_server_error(self):
+        message = PMMail(sender='from@example.com', to='to@example.com',
+            subject='Subject', text_body='Body', api_key='test')
+
+        with mock.patch('postmark.core.urlopen', side_effect=HTTPError('',
+            500, '', {}, None)):
+            self.assertRaises(PMMailServerErrorException, message.send)
+
+
+class PMBatchMailTests(unittest.TestCase):
+    def test_406_error_inactive_recipient(self):
+        messages = [
+            PMMail(
+                sender='from@example.com', to='to@example.com', 
+                subject='Subject', text_body='Body', api_key='test'
+            ),
+            PMMail(
+                sender='from@example.com', to='to@example.com',
+                subject='Subject', text_body='Body', api_key='test'
+            ),
+        ]
+
+        json_payload = StringIO.StringIO()
+        json_payload.write('{"Message": "", "ErrorCode": 406}')
+        json_payload.seek(0)
+
+        batch = PMBatchMail(messages=messages, api_key='test')
+
+        with mock.patch('postmark.core.urlopen', side_effect=HTTPError('',
+            422, '', {}, json_payload)):
+            self.assertRaises(PMMailInactiveRecipientException, batch.send)
+
+    def test_422_error_unprocessable_entity(self):
+        messages = [
+            PMMail(
+                sender='from@example.com', to='to@example.com',
+                subject='Subject', text_body='Body', api_key='test'
+            ),
+            PMMail(
+                sender='from@example.com', to='to@example.com',
+                subject='Subject', text_body='Body', api_key='test'
+            ),
+        ]
+
+        json_payload = StringIO.StringIO()
+        json_payload.write('{"Message": "", "ErrorCode": 422}')
+        json_payload.seek(0)
+
+        batch = PMBatchMail(messages=messages, api_key='test')
+
+        with mock.patch('postmark.core.urlopen', side_effect=HTTPError('',
+            422, '', {}, json_payload)):
+            self.assertRaises(PMMailUnprocessableEntityException, batch.send)
+
+    def test_500_error_server_error(self):
+        messages = [
+            PMMail(
+                sender='from@example.com', to='to@example.com',
+                subject='Subject', text_body='Body', api_key='test'
+            ),
+            PMMail(
+                sender='from@example.com', to='to@example.com',
+                subject='Subject', text_body='Body', api_key='test'
+            ),
+        ]
+
+        batch = PMBatchMail(messages=messages, api_key='test')
+
+        with mock.patch('postmark.core.urlopen', side_effect=HTTPError('',
+            500, '', {}, None)):
+            self.assertRaises(PMMailServerErrorException, batch.send)
+
+
+if __name__ == '__main__':
+    if not settings.configured:
+        settings.configure(
+            DATABASES={
+                'default': {
+                    'ENGINE': 'django.db.backends.sqlite3',
+                }
+            },
+            INSTALLED_APPS=[
+            ],
+            MIDDLEWARE_CLASSES=[],
+        )
+
+    unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,10 @@
 import sys
-import StringIO
 import unittest
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 if sys.version_info[0] < 3:
     from urllib2 import HTTPError
@@ -19,7 +23,7 @@ from django.conf import settings
 
 class PMMailTests(unittest.TestCase):
     def test_406_error_inactive_recipient(self):
-        json_payload = StringIO.StringIO()
+        json_payload = StringIO()
         json_payload.write('{"Message": "", "ErrorCode": 406}')
         json_payload.seek(0)
 
@@ -31,7 +35,7 @@ class PMMailTests(unittest.TestCase):
             self.assertRaises(PMMailInactiveRecipientException, message.send)
 
     def test_422_error_unprocessable_entity(self):
-        json_payload = StringIO.StringIO()
+        json_payload = StringIO()
         json_payload.write('{"Message": "", "ErrorCode": 422}')
         json_payload.seek(0)
 
@@ -64,7 +68,7 @@ class PMBatchMailTests(unittest.TestCase):
             ),
         ]
 
-        json_payload = StringIO.StringIO()
+        json_payload = StringIO()
         json_payload.write('{"Message": "", "ErrorCode": 406}')
         json_payload.seek(0)
 
@@ -86,7 +90,7 @@ class PMBatchMailTests(unittest.TestCase):
             ),
         ]
 
-        json_payload = StringIO.StringIO()
+        json_payload = StringIO()
         json_payload.write('{"Message": "", "ErrorCode": 422}')
         json_payload.seek(0)
 


### PR DESCRIPTION
#### Any background context you want to provide?
If you send email via Postmark to an inactive recipient, postmark returns a 422 status code with a 406 error. If this is for a single email, the email is not sent, but if this is in a batch request, the rest of the emails in the batch job are still sent.

#### What's this PR do?
For a single email, raise a new `PMMailInactiveRecipientException` error when a 406 is returned. For a batch job, finish sending all chunks and return the new `PMMailInactiveRecipientException` when all emails have been sent. This fixes the case where an inactive recipient would stop your entire mass email from sending.

Added python 3 support on the PMBatchMail class. The same changes were previously done to the PMMail class.

Also added a basic test structure and some tests around exceptions. A travis config is included. If you go to Travis CI and enable this repository, Travis will run tests automatically.

Version was also bumped.
