### PR TITLE
add trove classifiers for Python 3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,11 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Communications :: Email',
     ]
 )


### PR DESCRIPTION
it looks like this works on Python 2.7+, adding appropriate trove classifiers