### PR TITLE
Fix unicode error when decoding 422 response

### DIFF
--- a/postmark/core.py
+++ b/postmark/core.py
@@ -458,7 +458,7 @@ class PMMail(object):
                 raise PMMailUnauthorizedException('Sending Unauthorized - incorrect API key.', err)
             elif err.code == 422:
                 try:
-                    jsontxt = err.read().decode()
+                    jsontxt = err.read().decode('utf8')
                     jsonobj = json.loads(jsontxt)
                     desc = jsonobj['Message']
                     error_code = jsonobj['ErrorCode']


### PR DESCRIPTION
Similar to #61, this adds the encoding to use to decode an "Unprocessable Entity" error to fix this exception:
```
  File "[...]/.venv/local/lib/python2.7/site-packages/postmark/core.py", line 461, in send
    jsontxt = err.read().decode()
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 75: ordinal not in range(128)
```
Reproducable e.g. by trying to send an email to `jonäs@example.com`