### PR TITLE
#47 Support inline images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG for python-postmark
 ===============================
 
+Version 0.4.10
+--------------
+- Added inline images support (#47)
+
 Version 0.4.9
 -------------
 - Tornado mixin (tigrus)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ See [CONTRIBUTORS.md](https://github.com/themartorana/python-postmark/blob/maste
 Changelog
 ----------
 
+Version 0.4.10
+- Added inline images support (issue #47, PR #64)
+
 Version 0.4.9
 - Tornado mixin (tigrus)
 - PMJSONEncoder unicode changes (mattrobenolt)
@@ -36,11 +39,6 @@ Version 0.4.6
 
 Version 0.4.5
 - Fix for Python 3 support (issue #42, PR #43) (mflaxman)
-
-Version 0.4.4
-- Minor code cleanup (Stranger6667)
-- Fix for Django 1.5+ ugettext_lazy strings being improperly converted (#11, #41) (justinabrahms, rduffield)
-- Demo brought up to Django 1.6 (catskul)
 
 *[See full changelog](https://github.com/themartorana/python-postmark/blob/master/CHANGELOG.md)*
 

--- a/postmark/__init__.py
+++ b/postmark/__init__.py
@@ -1,4 +1,4 @@
-__version__         = '0.4.8'
+__version__         = '0.4.10'
 __author__          = "Dave Martorana (http://davemartorana.com), Richard Cooper (http://frozenskys.com), Bill Jones (oraclebill), Dmitry Golomidov (deeGraYve)"
 __date__            = '2010-April-14'
 __url__             = 'http://postmarkapp.com'

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
 from distutils.core import setup
 
+import postmark
+
+
 setup(
     name="python-postmark",
-    version="0.4.9",
+    version=postmark.__version__,
     packages=['postmark'],
     author="Dave Martorana (http://davemartorana.com), Richard Cooper (http://frozenskys.com), Bill Jones (oraclebill), Dmitry Golomidov (deeGraYve)",
     license='BSD',

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,6 @@
 import sys
 import unittest
-
+from email.mime.image import MIMEImage
 
 from io import BytesIO
 
@@ -51,6 +51,32 @@ class PMMailTests(unittest.TestCase):
         with mock.patch('postmark.core.urlopen', side_effect=HTTPError('',
             500, '', {}, None)):
             self.assertRaises(PMMailServerErrorException, message.send)
+
+    def test_inline_attachments(self):
+        image = MIMEImage('image_file', 'png', name='image.png')
+        image_with_id = MIMEImage('inline_image_file', 'png', name='image_with_id.png')
+        image_with_id.add_header('Content-ID', '<image2@postmarkapp.com>')
+        inline_image = MIMEImage('inline_image_file', 'png', name='inline_image.png')
+        inline_image.add_header('Content-ID', '<image3@postmarkapp.com>')
+        inline_image.add_header('Content-Disposition', 'inline', filename='inline_image.png')
+
+        json_message = PMMail(
+            sender='from@example.com', to='to@example.com', subject='Subject', text_body='Body', api_key='test',
+            attachments=[
+                ('TextFile', 'content', 'text/plain'),
+                ('InlineImage', 'image_content', 'image/png', 'cid:image@postmarkapp.com'),
+                image,
+                image_with_id,
+                inline_image,
+            ]
+        ).to_json_message()
+        assert json_message['Attachments'] == [
+            {'Name': 'TextFile', 'Content': 'content', 'ContentType': 'text/plain'},
+            {'Name': 'InlineImage', 'Content': 'image_content', 'ContentType': 'image/png', 'ContentID': 'cid:image@postmarkapp.com'},
+            {'Name': 'image.png', 'Content': 'aW1hZ2VfZmlsZQ==\n', 'ContentType': 'image/png'},
+            {'Name': 'image_with_id.png', 'Content': 'aW5saW5lX2ltYWdlX2ZpbGU=\n', 'ContentType': 'image/png', 'ContentID': 'image2@postmarkapp.com'},
+            {'Name': 'inline_image.png', 'Content': 'aW5saW5lX2ltYWdlX2ZpbGU=\n', 'ContentType': 'image/png', 'ContentID': 'cid:image3@postmarkapp.com'},
+        ]
 
 
 class PMBatchMailTests(unittest.TestCase):

--- a/tests.py
+++ b/tests.py
@@ -63,9 +63,9 @@ class PMMailTests(unittest.TestCase):
         expected = [
             {'Name': 'TextFile', 'Content': 'content', 'ContentType': 'text/plain'},
             {'Name': 'InlineImage', 'Content': 'image_content', 'ContentType': 'image/png', 'ContentID': 'cid:image@postmarkapp.com'},
-            {'Name': 'image.png', 'Content': 'aW1hZ2VfZmlsZQ==\n', 'ContentType': 'image/png'},
-            {'Name': 'image_with_id.png', 'Content': 'aW5saW5lX2ltYWdlX2ZpbGU=\n', 'ContentType': 'image/png', 'ContentID': 'image2@postmarkapp.com'},
-            {'Name': 'inline_image.png', 'Content': 'aW5saW5lX2ltYWdlX2ZpbGU=\n', 'ContentType': 'image/png', 'ContentID': 'cid:image3@postmarkapp.com'},
+            {'Name': 'image.png', 'Content': 'aW1hZ2VfZmlsZQ==', 'ContentType': 'image/png'},
+            {'Name': 'image_with_id.png', 'Content': 'aW5saW5lX2ltYWdlX2ZpbGU=', 'ContentType': 'image/png', 'ContentID': 'image2@postmarkapp.com'},
+            {'Name': 'inline_image.png', 'Content': 'aW5saW5lX2ltYWdlX2ZpbGU=', 'ContentType': 'image/png', 'ContentID': 'cid:image3@postmarkapp.com'},
         ]
         json_message = PMMail(
             sender='from@example.com', to='to@example.com', subject='Subject', text_body='Body', api_key='test',
@@ -78,8 +78,9 @@ class PMMailTests(unittest.TestCase):
             ]
         ).to_json_message()
         assert len(json_message['Attachments']) == len(expected)
-        for item in expected:
-            assert item in json_message['Attachments']
+        for orig, attachment in zip(expected, json_message['Attachments']):
+            for k, v in orig.items():
+                assert orig[k] == attachment[k].rstrip()
 
 
 class PMBatchMailTests(unittest.TestCase):


### PR DESCRIPTION
Hello
I made support for sending inline images (and add `Content-ID` header to any attachments). See related issue: #47 

If you need any clarifications or code improvements, please, feel free to write me :)

**Related links:**
http://developer.postmarkapp.com/developer-send-api.html ("Inline image attachments")
https://tools.ietf.org/html/rfc2392
https://www.ietf.org/rfc/rfc1806.txt