### PR TITLE
Fix input argument checking, use custom set functions and validation

### DIFF
--- a/postmark/core.py
+++ b/postmark/core.py
@@ -118,9 +118,9 @@ class PMMail(object):
         for key in kwargs:
             if key in acceptable_keys:
                 if key == 'recipient':
-                    setattr(self, '_PMMail__to', kwargs[key])
+                    setattr(self, 'to', kwargs[key])
                 else:
-                    setattr(self, '_PMMail__%s' % key, kwargs[key])
+                    setattr(self, key, kwargs[key])
 
         # Set up the user-agent
         self.__user_agent = 'Python/%s (python-postmark library version %s)' % ('_'.join([str(var) for var in sys.version_info]), __version__)
@@ -323,6 +323,18 @@ class PMMail(object):
         '''
         Custom metadata key/value pairs returned by webhooks.
         '''
+    )
+
+    template_id = property(
+        lambda self: self.__template_id,
+        lambda self, value: setattr(self, '_PMMail__template_id', value),
+        lambda self: setattr(self, '_PMMail__template_id', {}),
+    )
+
+    template_model = property(
+        lambda self: self.__template_model,
+        lambda self, value: setattr(self, '_PMMail__template_model', value),
+        lambda self: setattr(self, '_PMMail__template_model', {}),
     )
 
     message_id = property(

--- a/tests.py
+++ b/tests.py
@@ -124,6 +124,17 @@ class PMMailTests(unittest.TestCase):
             for k, v in orig.items():
                 assert orig[k] == attachment[k].rstrip()
 
+    def test_send_metadata(self):
+        message = PMMail(api_key='test', sender='from@example.com', to='to@example.com',
+                         subject='test', text_body='test', metadata={'test': 'test'})
+        with mock.patch('postmark.core.urlopen', side_effect=HTTPError('',
+            200, '', {}, None)):
+            message.send()
+
+    def test_send_metadata_invalid_format(self):
+        self.assertRaises(TypeError, PMMail, api_key='test', sender='from@example.com', to='to@example.com',
+                         subject='test', text_body='test', metadata={'test': {}})
+
 
 class PMBatchMailTests(unittest.TestCase):
     def test_406_error_inactive_recipient(self):


### PR DESCRIPTION
It seems the custom _set methods for the overridden properties were never hooked up, so some validation was never happening.

This hooks them up and adds metadata tests.