### PR TITLE
Fixes a HTML content problem uncovered from django-post-office 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- '2.7'
 - '3.5'
 - '3.6'
 - '3.7'

--- a/postmark/django_backend.py
+++ b/postmark/django_backend.py
@@ -82,7 +82,7 @@ class EmailBackend(BaseEmailBackend):
                     html_body = alt[0]
                     break
 
-        elif getattr(message, 'content_subtype', None) == 'html':
+        if getattr(message, 'content_subtype', None) == 'html':
             # Don't send html content as plain text
             text_body = None
             html_body = message.body

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django==1.11.23
+Django==2.2.9
 mock

--- a/test/demo/forms.py
+++ b/test/demo/forms.py
@@ -9,14 +9,16 @@ class EmailForm(forms.Form):
     sender  = forms.EmailField(max_length=100, initial=settings.POSTMARK_SENDER)
     to      = forms.CharField(initial='bill@averline.com')
     subject = forms.CharField(initial='test email')    
-    body    = forms.CharField(widget=forms.Textarea, initial='this is a test')    
+    body    = forms.CharField(widget=forms.Textarea, initial='this is a test')
+    html_body = forms.CharField(widget=forms.Textarea, initial='<h1>Test</h1>This is a test')
 
     def save(self, fail_silently=False):
         """
         Build and send the email message.
         """
-        send_mail(subject=unicode(ugettext_lazy(self.cleaned_data['subject'])),
-                  message=self.cleaned_data['body'], 
+        send_mail(subject=str(ugettext_lazy(self.cleaned_data['subject'])),
+                  message=self.cleaned_data['body'],
+                  html_message=self.cleaned_data['html_body'],
                   from_email=self.cleaned_data['sender'],
                   recipient_list=[addr.strip() for addr in self.cleaned_data['to'].split(',')],
                   fail_silently=fail_silently)

--- a/test/demo/settings.py
+++ b/test/demo/settings.py
@@ -33,7 +33,7 @@ INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',
-    'django.contrib.admin',
+    # 'django.contrib.admin',
  )
 
 MIDDLEWARE_CLASSES = (
@@ -41,9 +41,12 @@ MIDDLEWARE_CLASSES = (
 
 ROOT_URLCONF = 'urls'
 
-TEMPLATE_DIRS = (
-    os.path.join(settings_path, 'templates'),
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [os.path.join(settings_path, 'templates')],
+    }
+]
 
 #EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 #EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'

--- a/test/demo/urls.py
+++ b/test/demo/urls.py
@@ -3,7 +3,8 @@ from django.conf.urls import *
 # Uncomment the next two lines to enable the admin:
 # from django.contrib import admin
 # admin.autodiscover()
+import views
 
-urlpatterns = patterns('',
-    (r'', 'views.test_email'),
-)
+urlpatterns = [
+    url(r'', views.test_email),
+]

--- a/tests.py
+++ b/tests.py
@@ -230,7 +230,7 @@ class EmailBackendTests(TestCase):
 
         with mock.patch('postmark.core.urlopen', side_effect=HTTPError('', 200, '', {}, None)) as transport:
             message.send()
-            data = json.loads(transport.call_args[0][0].data)
+            data = json.loads(transport.call_args[0][0].data.decode('utf-8'))
             self.assertEqual('hello there', data['TextBody'])
             self.assertEqual('<b>hello</b> there', data['HtmlBody'])
 
@@ -244,7 +244,7 @@ class EmailBackendTests(TestCase):
 
         with mock.patch('postmark.core.urlopen', side_effect=HTTPError('', 200, '', {}, None)) as transport:
             message.send()
-            data = json.loads(transport.call_args[0][0].data)
+            data = json.loads(transport.call_args[0][0].data.decode('utf-8'))
             self.assertEqual('<b>hello</b> there', data['HtmlBody'])
             self.assertFalse('TextBody' in data)
 
@@ -263,7 +263,7 @@ class EmailBackendTests(TestCase):
 
         with mock.patch('postmark.core.urlopen', side_effect=HTTPError('', 200, '', {}, None)) as transport:
             message.send()
-            data = json.loads(transport.call_args[0][0].data)
+            data = json.loads(transport.call_args[0][0].data.decode('utf-8'))
             self.assertFalse('TextBody' in data)
             self.assertEqual('<b>hello</b> there', data['HtmlBody'])
 

--- a/tests.py
+++ b/tests.py
@@ -1,8 +1,14 @@
+import json
 import sys
 import unittest
 from email.mime.image import MIMEImage
 
 from io import BytesIO
+
+from django.core.mail import EmailMultiAlternatives, EmailMessage
+from django.test import override_settings, TestCase
+
+from postmark.django_backend import EmailBackend
 
 if sys.version_info[0] < 3:
     from StringIO import StringIO
@@ -206,7 +212,60 @@ class PMBounceManagerTests(unittest.TestCase):
 
         with mock.patch('postmark.core.HTTPConnection.getresponse') as mock_response:
             mock_response.return_value = StringIO('{"test": "test"}')
-            self.assertEquals(bounce.activate(1), {'test': 'test'})
+            self.assertEqual(bounce.activate(1), {'test': 'test'})
+
+
+class EmailBackendTests(TestCase):
+
+    def setUp(self):
+        self.backend = EmailBackend(api_key='dummy')
+
+    def test_send_multi_alternative_html_email(self):
+        # build a message and send it
+        message = EmailMultiAlternatives(
+            connection=self.backend,
+            from_email='from@test.com', to=['recipient@test.com'], subject='html test', body='hello there'
+        )
+        message.attach_alternative('<b>hello</b> there', 'text/html')
+
+        with mock.patch('postmark.core.urlopen', side_effect=HTTPError('', 200, '', {}, None)) as transport:
+            message.send()
+            data = json.loads(transport.call_args[0][0].data)
+            self.assertEqual('hello there', data['TextBody'])
+            self.assertEqual('<b>hello</b> there', data['HtmlBody'])
+
+    def test_send_content_subtype_email(self):
+        # build a message and send it
+        message = EmailMessage(
+            connection=self.backend,
+            from_email='from@test.com', to=['recipient@test.com'], subject='html test', body='<b>hello</b> there'
+        )
+        message.content_subtype = 'html'
+
+        with mock.patch('postmark.core.urlopen', side_effect=HTTPError('', 200, '', {}, None)) as transport:
+            message.send()
+            data = json.loads(transport.call_args[0][0].data)
+            self.assertEqual('<b>hello</b> there', data['HtmlBody'])
+            self.assertFalse('TextBody' in data)
+
+    def test_send_multi_alternative_with_subtype_html_email(self):
+        """
+        Client uses EmailMultiAlternative but instead of specifying a html alternative they insert html content
+        into the main message and specify message_subtype
+        :return:
+        """
+        message = EmailMultiAlternatives(
+            connection=self.backend,
+            from_email='from@test.com', to=['recipient@test.com'], subject='html test', body='<b>hello</b> there'
+        )
+        # NO alternatives attached.  subtype specified instead
+        message.content_subtype = 'html'
+
+        with mock.patch('postmark.core.urlopen', side_effect=HTTPError('', 200, '', {}, None)) as transport:
+            message.send()
+            data = json.loads(transport.call_args[0][0].data)
+            self.assertFalse('TextBody' in data)
+            self.assertEqual('<b>hello</b> there', data['HtmlBody'])
 
 
 if __name__ == '__main__':
@@ -215,6 +274,7 @@ if __name__ == '__main__':
             DATABASES={
                 'default': {
                     'ENGINE': 'django.db.backends.sqlite3',
+                    'NAME': ':memory:'
                 }
             },
             INSTALLED_APPS=[


### PR DESCRIPTION
Allows for sending EmailMultiAlternatives messages with content_subtype html and without text/html alternative

tests mimic django-post-office 3 implementation here
https://github.com/ui/django-post_office/blob/v3.2.1/post_office/models.py#L126