### PR TITLE
Make MessageID accessible via Django backend

### DIFF
--- a/postmark/django_backend.py
+++ b/postmark/django_backend.py
@@ -53,6 +53,7 @@ class EmailBackend(BaseEmailBackend):
             raise ImproperlyConfigured('POSTMARK API key must be set in Django settings file or passed to backend constructor.')
         self.default_sender = getattr(settings, 'POSTMARK_SENDER', default_sender)
         self.test_mode = getattr(settings, 'POSTMARK_TEST_MODE', False)
+        self.return_message_id = getattr(settings, 'POSTMARK_RETURN_MESSAGE_ID', False)
 
     def send_messages(self, email_messages):
         """
@@ -147,7 +148,8 @@ class EmailBackend(BaseEmailBackend):
             to_send = PMBatchMail(messages=pm_messages)
         try:
             to_send.send(test=self.test_mode)
-            return str(to_send.message_id)
+            if self.return_message_id:
+                return str(to_send.message_id)
         except:
             if self.fail_silently:
                 return False

--- a/postmark/django_backend.py
+++ b/postmark/django_backend.py
@@ -62,8 +62,10 @@ class EmailBackend(BaseEmailBackend):
         if not email_messages:
             return
         sent = self._send(email_messages)
-        if sent:
+        if sent is True:
             return len(email_messages)
+        else:
+            return sent
         return 0
 
     def _build_message(self, message):
@@ -145,6 +147,7 @@ class EmailBackend(BaseEmailBackend):
             to_send = PMBatchMail(messages=pm_messages)
         try:
             to_send.send(test=self.test_mode)
+            return str(to_send.message_id)
         except:
             if self.fail_silently:
                 return False


### PR DESCRIPTION
It's helpful to be able to log the MessageID for each email sent through the Postmark backend. This pull request introduces a new setting `POSTMARK_RETURN_MESSAGE_ID` (default False) that instructs the Postmark backend to return the MessageID field from the API response whens sending email.

This pull request is in reference to this open issue: https://github.com/themartorana/python-postmark/issues/59

The code solution is based on this commit from andrebaptista's fork: https://github.com/andrebaptista/python-postmark/commit/cc4e8130190c4fa7d6d42a1b014169f4987e0260