### PR TITLE
Allow django_backend to take advantage of message_streams

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28,5 +28,6 @@ Everyone that made python-postmark awesome
 - Nikolay Fominykh (https://github.com/tigrus)
 - Gabe Limon (https://github.com/gabelimon)
 - Olle Hellgren (https://github.com/anulaibar)
+- Harry Khanna (https://www.khanna.law/)
 
 (Did I miss anyone?)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ mail = EmailMultiAlternatives(subject, msg_plain, from_email, recipients, connec
 mail.tag = tag
 mail.send()
 ```
+
+#### Setting the `message_stream`
+```python
+from django.core.mail import get_connection, EmailMultiAlternatives
+
+mail = EmailMultiAlternatives(subject, msg_plain, from_email, recipients, connection=connection, headers=headers)
+
+mail.message_stream = "broadcast"
+mail.send()
+```
+
     
 Tornado
 -------

--- a/postmark/django_backend.py
+++ b/postmark/django_backend.py
@@ -21,6 +21,11 @@ class PMEmailMessage(EmailMessage):
         else:
             self.track_opens = getattr(settings, 'POSTMARK_TRACK_OPENS', False)
 
+        if 'message_stream' in kwargs:
+            self.message_stream = kwargs['message_stream']
+        else:
+            self.message_stream = None
+
         super(PMEmailMessage, self).__init__(*args, **kwargs)
 
 
@@ -37,6 +42,12 @@ class PMEmailMultiAlternatives(EmailMultiAlternatives):
             del kwargs['track_opens']
         else:
             self.track_opens = getattr(settings, 'POSTMARK_TRACK_OPENS', False)
+
+        if 'message_stream' in kwargs:
+            self.message_stream = kwargs['message_stream']
+        else:
+            self.message_stream = None
+
 
         super(PMEmailMultiAlternatives, self).__init__(*args, **kwargs)
 
@@ -117,6 +128,7 @@ class EmailBackend(BaseEmailBackend):
                     else:
                         attachments.append(item)
 
+        message_stream = getattr(message, "message_stream", None)
         postmark_message = PMMail(api_key=self.api_key,
                                   subject=message.subject,
                                   sender=message.from_email,
@@ -127,7 +139,8 @@ class EmailBackend(BaseEmailBackend):
                                   html_body=html_body,
                                   reply_to=reply_to,
                                   custom_headers=custom_headers,
-                                  attachments=attachments)
+                                  attachments=attachments,
+                                  message_stream=message_stream)
 
         postmark_message.tag = getattr(message, 'tag', None)
         postmark_message.track_opens = getattr(message, 'track_opens', False)

--- a/postmark/django_backend.py
+++ b/postmark/django_backend.py
@@ -23,6 +23,7 @@ class PMEmailMessage(EmailMessage):
 
         if 'message_stream' in kwargs:
             self.message_stream = kwargs['message_stream']
+            del kwargs['message_stream']
         else:
             self.message_stream = None
 
@@ -45,6 +46,7 @@ class PMEmailMultiAlternatives(EmailMultiAlternatives):
 
         if 'message_stream' in kwargs:
             self.message_stream = kwargs['message_stream']
+            del kwargs['message_stream']
         else:
             self.message_stream = None
 
@@ -128,7 +130,7 @@ class EmailBackend(BaseEmailBackend):
                     else:
                         attachments.append(item)
 
-        message_stream = getattr(message, "message_stream", None)
+        message_stream = getattr(message, 'message_stream', None)
         postmark_message = PMMail(api_key=self.api_key,
                                   subject=message.subject,
                                   sender=message.from_email,


### PR DESCRIPTION
#94 allowed the `PMMail` class to add a `message_stream`, but this functionality was not provided to the ordinary django_backend. This PR allows a developer to set the `message_stream` attribute on the `EmailMessage` instance to use a non-default message stream.