### PR TITLE
Add support to use template aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Using templates in python-postmark is straightforward:
 
 3. Make a dict in python that contains the values of the template variables. Postmark calls this the "TemplateModel"
 
-4. Instantiate PMMail with the the appropriate kwargs, including "template_id" and "template_model". NOTE: "subject" kwarg is ignored.
+4. Instantiate PMMail with the appropriate kwargs, including "template_id" and "template_model". NOTE: "subject" kwarg is ignored.
+   - "template_id" can be substituted for "template_alias" if you wish to send using Postmark's template alias feature.
 
 5. Call the send() method
 

--- a/postmark/core.py
+++ b/postmark/core.py
@@ -407,7 +407,10 @@ class PMMail(object):
                 'Cannot send a template e-mail without a both template_id and template_model set')
         elif self.__template_alias and not all([self.__template_alias, self.__template_model]):
             raise PMMailMissingValueException(
-                'Cannot send a alias e-mail without both a template_alias and template_model set')
+                'Cannot send a template e-mail without both a template_alias and template_model set')
+        elif self.__template_model and not any([self.__template_id, self.__template_alias]):
+            raise PMMailMissingValueException(
+                'Cannot send a template e-mail without either a template_id or template_alias set')
         elif not any([self.__template_id, self.__template_alias, self.__template_model, self.__subject]):
             raise PMMailMissingValueException('Cannot send an e-mail without a subject')
         elif not self.__html_body and not self.__text_body and not (self.__template_id or self.__template_alias):

--- a/tests.py
+++ b/tests.py
@@ -123,7 +123,7 @@ class PMMailTests(unittest.TestCase):
             client.send, 'Cannot send a template e-mail without both a template_alias and template_model set'
         )
 
-    def test_check_values_bad_template_alias_data(self):
+    def test_check_values_bad_template_model_data(self):
         client = PMMail(api_key='test', sender='from@example.com', to='to@example.com', template_model={'junk': 'more junk'})
         self.assert_missing_value_exception(
             client.send, 'Cannot send a template e-mail without either a template_id or template_alias set'

--- a/tests.py
+++ b/tests.py
@@ -117,10 +117,16 @@ class PMMailTests(unittest.TestCase):
             200, '', {}, None)):
             message.send()
 
-    def test_check_values_bad_alias_data(self):
+    def test_check_values_bad_template_alias_data(self):
         client = PMMail(api_key='test', sender='from@example.com', to='to@example.com', template_alias='my-template-alias')
         self.assert_missing_value_exception(
-            client.send, 'Cannot send a alias e-mail without both a template_alias and template_model set'
+            client.send, 'Cannot send a template e-mail without both a template_alias and template_model set'
+        )
+
+    def test_check_values_bad_template_alias_data(self):
+        client = PMMail(api_key='test', sender='from@example.com', to='to@example.com', template_model={'junk': 'more junk'})
+        self.assert_missing_value_exception(
+            client.send, 'Cannot send a template e-mail without either a template_id or template_alias set'
         )
 
     def test_send_with_alias(self):

--- a/tests.py
+++ b/tests.py
@@ -117,6 +117,23 @@ class PMMailTests(unittest.TestCase):
             200, '', {}, None)):
             message.send()
 
+    def test_check_values_bad_alias_data(self):
+        client = PMMail(api_key='test', sender='from@example.com', to='to@example.com', template_alias='my-template-alias')
+        self.assert_missing_value_exception(
+            client.send, 'Cannot send a alias e-mail without both a template_alias and template_model set'
+        )
+
+    def test_send_with_alias(self):
+        message = PMMail(
+            api_key='test',
+            sender='from@example.com',
+            to='to@example.com',
+            template_alias='my-template-alias',
+            template_model={'junk': 'more junk'},
+        )
+        with mock.patch('postmark.core.urlopen', side_effect=HTTPError('', 200, '', {}, None)):
+            message.send()
+
     def test_inline_attachments(self):
         image = MIMEImage(b'image_file', 'png', name='image.png')
         image_with_id = MIMEImage(b'inline_image_file', 'png', name='image_with_id.png')


### PR DESCRIPTION
For https://github.com/themartorana/python-postmark/issues/81

Did it with a subclass in a project so trying to back port it into the core library made sense.